### PR TITLE
feat: adding annotated types and a Pydantic model for ASAs

### DIFF
--- a/humblepy/models/__init__.py
+++ b/humblepy/models/__init__.py
@@ -1,0 +1,1 @@
+"""Pydantic models for Algorand assets and transactions."""

--- a/humblepy/models/asa.py
+++ b/humblepy/models/asa.py
@@ -1,0 +1,67 @@
+"""Data validation for Algorand Standard Assets (ASAs)."""
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+)
+
+from humblepy.types.annotated import (
+    AlgorandAddress,
+    AlgorandHash,
+    AsaAssetName,
+    AsaDecimals,
+    AsaUnitName,
+    AsaUrl,
+    Uint64,
+)
+
+
+class Asa(BaseModel):
+    """A Pydantic model for Algorand Standard Assets (ASAs)."""
+
+    model_config = ConfigDict(frozen=True)
+
+    total: Uint64 = Field(
+        description="The total number of base units of the asset to create."
+    )
+    decimals: AsaDecimals = Field(
+        default=0,
+        description="The number of digits to use after the decimal point when displaying the asset. If 0, the asset is not divisible. If 1, the base unit of the asset is in tenths. Must be between 0 and 19, inclusive.",
+    )
+    default_frozen: bool = Field(
+        default=False,
+        description="Whether slots for this asset in user accounts are frozen by default.",
+    )
+    unit_name: AsaUnitName | None = Field(
+        default=None,
+        description="The name of a unit of this asset. Max size is 8 bytes. Example: 'USDT'.",
+    )
+    asset_name: AsaAssetName | None = Field(
+        default=None,
+        description="The name of the asset. Max size is 32 bytes. Example: 'Tether'.",
+    )
+    url: AsaUrl | None = Field(
+        default=None,
+        description="Specifies a URL where more information about the asset can be retrieved. Max size is 96 bytes.",
+    )
+    metadata_hash: AlgorandHash | None = Field(
+        default=None,
+        description="This field is intended to be a 32-byte hash of some metadata that is relevant to your asset and/or asset holders.",
+    )
+    manager: AlgorandAddress | None = Field(
+        default=None,
+        description="The address of the account that can manage the configuration of the asset and destroy it.",
+    )
+    reserve: AlgorandAddress | None = Field(
+        default=None,
+        description="The address of the account that holds the reserve (non-minted) units of the asset.",
+    )
+    freeze: AlgorandAddress | None = Field(
+        default=None,
+        description="The address of the account used to freeze holdings of this asset. If empty, freezing is not permitted.",
+    )
+    clawback: AlgorandAddress | None = Field(
+        default=None,
+        description="The address of the account that can clawback holdings of this asset. If empty, clawback is not permitted.",
+    )

--- a/humblepy/types/__init__.py
+++ b/humblepy/types/__init__.py
@@ -1,0 +1,1 @@
+"""Types for humblepy."""

--- a/humblepy/types/annotated.py
+++ b/humblepy/types/annotated.py
@@ -1,0 +1,35 @@
+"""Annotated types for Pydantic models."""
+
+from functools import partial
+from typing import Annotated
+
+from algosdk.constants import HASH_LEN, MAX_ASSET_DECIMALS
+from annotated_types import Ge, Le, Len, Lt
+from pydantic import AfterValidator
+from pydantic_core import Url
+
+from humblepy.utils.validate import (
+    validate_address,
+    validate_encoded_length,
+)
+
+# Generic types
+Uint32 = Annotated[int, Ge(0), Lt(2**32)]
+Uint64 = Annotated[int, Ge(0), Lt(2**64)]
+
+# Algorand types
+AlgorandHash = Annotated[bytes, Len(HASH_LEN, HASH_LEN)]  # 32 bytes
+AlgorandAddress = Annotated[str, AfterValidator(validate_address)]
+
+# Algorand Standard Asset (ASA) types
+AsaDecimals = Annotated[Uint32, Ge(0), Le(MAX_ASSET_DECIMALS)]  # <= 19
+AsaUnitName = Annotated[
+    str, AfterValidator(partial(validate_encoded_length, max_length=8))
+]
+AsaAssetName = Annotated[
+    str, AfterValidator(partial(validate_encoded_length, max_length=32))
+]
+AsaUrl = Annotated[
+    Url,
+    AfterValidator(partial(validate_encoded_length, max_length=96)),
+]

--- a/poetry.lock
+++ b/poetry.lock
@@ -24,18 +24,18 @@ files = [
 
 [[package]]
 name = "bandit"
-version = "1.7.5"
+version = "1.7.6"
 description = "Security oriented static analyser for python code."
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "bandit-1.7.5-py3-none-any.whl", hash = "sha256:75665181dc1e0096369112541a056c59d1c5f66f9bb74a8d686c3c362b83f549"},
-    {file = "bandit-1.7.5.tar.gz", hash = "sha256:bdfc739baa03b880c2d15d0431b31c658ffc348e907fe197e54e0389dd59e11e"},
+    {file = "bandit-1.7.6-py3-none-any.whl", hash = "sha256:36da17c67fc87579a5d20c323c8d0b1643a890a2b93f00b3d1229966624694ff"},
+    {file = "bandit-1.7.6.tar.gz", hash = "sha256:72ce7bc9741374d96fb2f1c9a8960829885f1243ffde743de70a19cee353e8f3"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.3.9", markers = "platform_system == \"Windows\""}
-GitPython = ">=1.0.1"
+GitPython = ">=3.1.30"
 PyYAML = ">=5.3.1"
 rich = "*"
 stevedore = ">=1.20.0"
@@ -869,13 +869,13 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "pre-commit"
-version = "3.5.0"
+version = "3.6.0"
 description = "A framework for managing and maintaining multi-language pre-commit hooks."
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 files = [
-    {file = "pre_commit-3.5.0-py2.py3-none-any.whl", hash = "sha256:841dc9aef25daba9a0238cd27984041fa0467b4199fc4852e27950664919f660"},
-    {file = "pre_commit-3.5.0.tar.gz", hash = "sha256:5804465c675b659b0862f07907f96295d490822a450c4c40e747d0b1c6ebcb32"},
+    {file = "pre_commit-3.6.0-py2.py3-none-any.whl", hash = "sha256:c255039ef399049a5544b6ce13d135caba8f2c28c3b4033277a788f434308376"},
+    {file = "pre_commit-3.6.0.tar.gz", hash = "sha256:d30bad9abf165f7785c15a21a1f46da7d0677cb00ee7ff4c579fd38922efe15d"},
 ]
 
 [package.dependencies]
@@ -1649,4 +1649,4 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "c273324a4dba85db2f2fdec4fe86e269259eab845bad6881207eb599f7fbec26"
+content-hash = "4983723db597057496bfaa0b16b4626125c26ee9ec193bf3f87659a0e4e062f1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "humblepy"
-version = "0.2.0"
+version = "0.3.0"
 description = "A type-safe Python library for interacting with assets on Algorand."
 readme = "README.md"
 authors = ["humblepy <alexandercodes@proton.me>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,10 +46,10 @@ export = "poetry_plugin_export.plugins:ExportApplicationPlugin"
 
 
 [tool.poetry.group.dev.dependencies]
-bandit = "^1.7.5"
+bandit = "^1.7.6"
 mypy = "^1.7.1"
 mypy-extensions = "^1.0.0"
-pre-commit = "^3.5.0"
+pre-commit = "^3.6.0"
 pydocstyle = "^6.3.0"
 pylint = "^3.0.2"
 pytest = "^7.4.3"

--- a/tests/test_models/test_asa.py
+++ b/tests/test_models/test_asa.py
@@ -1,0 +1,163 @@
+"""Unit tests for the ASA pydantic model."""
+
+import pytest
+from pydantic import ValidationError
+
+from humblepy.models.asa import Asa
+from humblepy.types.annotated import (
+    AlgorandAddress,
+    AlgorandHash,
+    AsaAssetName,
+    AsaDecimals,
+    AsaUnitName,
+    AsaUrl,
+    Uint64,
+)
+
+
+def test_total_is_mandatory():
+    """Test that `total` is mandatory."""
+    with pytest.raises(ValidationError):
+        Asa()  # type: ignore
+
+
+def test_total_is_uint64():
+    """Test that `total` is `Uint64`."""
+    assert Asa.model_fields["total"].rebuild_annotation() == Uint64
+
+
+def test_total_strict():
+    """Test that `total` raises an error in strict mode if passed a float or a string."""
+    with pytest.raises(ValidationError):
+        Asa.model_validate({"total": 1.0}, strict=True)
+    with pytest.raises(ValidationError):
+        Asa.model_validate({"total": "1"}, strict=True)
+
+
+def test_total_non_strict():
+    """Test that `total` does not raise an error in non-strict mode if passed a float or a string."""
+    assert Asa.model_validate({"total": 1.0}, strict=False) == Asa(total=1)
+    assert Asa.model_validate({"total": "1"}, strict=False) == Asa(total=1)
+
+
+def test_decimals_default_is_zero():
+    """Test that `decimals` defaults to zero."""
+    assert Asa(total=1).decimals == 0
+
+
+def test_decimals_is_asa_decimals():
+    """Test that `decimals` `AsaDecimals`."""
+    assert Asa.model_fields["decimals"].rebuild_annotation() == AsaDecimals
+
+
+def test_default_frozen_default_is_false():
+    """Test that `default_frozen` defaults to `False`."""
+    assert Asa(total=1).default_frozen is False
+
+
+def test_default_frozen_strict():
+    """Test that `default_frozen` raises an error in strict mode if passed a non-boolean type."""
+    with pytest.raises(ValidationError):
+        Asa.model_validate({"total": 1, "default_frozen": 1}, strict=True)
+    with pytest.raises(ValidationError):
+        Asa.model_validate({"total": 1, "default_frozen": 1.0}, strict=True)
+    with pytest.raises(ValidationError):
+        Asa.model_validate({"total": 1, "default_frozen": "True"}, strict=True)
+    with pytest.raises(ValidationError):
+        Asa.model_validate({"total": 1, "default_frozen": "true"}, strict=True)
+
+
+def test_default_frozen_non_strict():
+    """Test that `default_frozen` does not raise an error in non-strict mode if passed a valid non-boolean type value."""
+    assert Asa.model_validate({"total": 1, "default_frozen": 1}, strict=False) == Asa(
+        total=1, default_frozen=True
+    )
+    assert Asa.model_validate({"total": 1, "default_frozen": 1.0}, strict=False) == Asa(
+        total=1, default_frozen=True
+    )
+    assert Asa.model_validate(
+        {"total": 1, "default_frozen": "True"}, strict=False
+    ) == Asa(total=1, default_frozen=True)
+    assert Asa.model_validate(
+        {"total": 1, "default_frozen": "true"}, strict=False
+    ) == Asa(total=1, default_frozen=True)
+
+
+def test_unit_name_default_is_none():
+    """Test that `unit_name` defaults to `None`."""
+    assert Asa(total=1).unit_name is None
+
+
+def test_unit_name_is_asa_unit_name_or_none():
+    """Test that `unit_name` is `AsaUnitName` or `None`."""
+    assert Asa.model_fields["unit_name"].rebuild_annotation() == AsaUnitName | None
+
+
+def test_asset_name_default_is_none():
+    """Test that `asset_name` defaults to `None`."""
+    assert Asa(total=1).asset_name is None
+
+
+def test_asset_name_is_asa_asset_name_or_none():
+    """Test that `asset_name` is `AsaAssetName` or `None`."""
+    assert Asa.model_fields["asset_name"].rebuild_annotation() == AsaAssetName | None
+
+
+def test_url_default_is_none():
+    """Test that `url` defaults to `None`."""
+    assert Asa(total=1).url is None
+
+
+def test_url_is_asa_url_or_none():
+    """Test that `url` is `AsaUrl` or `None`."""
+    assert Asa.model_fields["url"].rebuild_annotation() == AsaUrl | None
+
+
+def test_metadata_hash_default_is_none():
+    """Test that `metadata_hash` defaults to `None`."""
+    assert Asa(total=1).metadata_hash is None
+
+
+def test_metadata_hash_is_algorand_hash_or_none():
+    """Test that `metadata_hash` is `AlgorandHash` or `None`."""
+    assert Asa.model_fields["metadata_hash"].rebuild_annotation() == AlgorandHash | None
+
+
+def test_manager_default_is_none():
+    """Test that `manager` defaults to `None`."""
+    assert Asa(total=1).manager is None
+
+
+def test_manager_is_algorand_address_or_none():
+    """Test that `manager` is `AlgorandAddress` or `None`."""
+    assert Asa.model_fields["manager"].rebuild_annotation() == AlgorandAddress | None
+
+
+def test_reserve_default_is_none():
+    """Test that `reserve` defaults to `None`."""
+    assert Asa(total=1).reserve is None
+
+
+def test_reserve_is_algorand_address_or_none():
+    """Test that `reserve` is `AlgorandAddress` or `None`."""
+    assert Asa.model_fields["reserve"].rebuild_annotation() == AlgorandAddress | None
+
+
+def test_freeze_default_is_none():
+    """Test that `freeze` defaults to `None`."""
+    assert Asa(total=1).freeze is None
+
+
+def test_freeze_is_algorand_address_or_none():
+    """Test that `freeze` is `AlgorandAddress` or `None`."""
+    assert Asa.model_fields["freeze"].rebuild_annotation() == AlgorandAddress | None
+
+
+def test_clawback_default_is_none():
+    """Test that `clawback` defaults to `None`."""
+    assert Asa(total=1).clawback is None
+
+
+def test_clawback_is_algorand_address_or_none():
+    """Test that `clawback` is `AlgorandAddress` or `None`."""
+    assert Asa.model_fields["clawback"].rebuild_annotation() == AlgorandAddress | None

--- a/tests/test_types/test_annotated.py
+++ b/tests/test_types/test_annotated.py
@@ -1,0 +1,155 @@
+"""Unit tests for the annotated types."""
+
+import pytest
+from algosdk.constants import HASH_LEN, MAX_ASSET_DECIMALS
+from pydantic import TypeAdapter, ValidationError
+
+from humblepy.types.annotated import (
+    AlgorandAddress,
+    AlgorandHash,
+    AsaAssetName,
+    AsaDecimals,
+    AsaUnitName,
+    AsaUrl,
+    Uint32,
+    Uint64,
+)
+
+
+def test_uint32_out_of_bounds():
+    """Test that `Uint32` raises an error if the value is out of bounds."""
+    ta = TypeAdapter(Uint32)
+    with pytest.raises(ValidationError):
+        ta.validate_python(-1)
+    with pytest.raises(ValidationError):
+        ta.validate_python(2**32)
+
+
+def test_uint32_in_bounds():
+    """Test that `Uint32` does not raise an error if the value is in bounds."""
+    ta = TypeAdapter(Uint32)
+    assert ta.validate_python(0) == 0
+    assert ta.validate_python(1) == 1
+    assert ta.validate_python(2**32 - 1) == 2**32 - 1
+
+
+def test_uint64_out_of_bounds():
+    """Test that `Uint64` raises an error if the value is out of bounds."""
+    ta = TypeAdapter(Uint64)
+    with pytest.raises(ValidationError):
+        ta.validate_python(-1)
+    with pytest.raises(ValidationError):
+        ta.validate_python(2**64)
+
+
+def test_uint64_in_bounds():
+    """Test that `Uint64` does not raise an error if the value is in bounds."""
+    ta = TypeAdapter(Uint64)
+    assert ta.validate_python(0) == 0
+    assert ta.validate_python(1) == 1
+    assert ta.validate_python(2**64 - 1) == 2**64 - 1
+
+
+def test_algorand_hash_length_out_of_bounds():
+    """Test that `AlgorandHash` raises an error if the value is out of bounds."""
+    ta = TypeAdapter(AlgorandHash)
+    with pytest.raises(ValidationError):
+        ta.validate_python(b"")
+    with pytest.raises(ValidationError):
+        ta.validate_python(b"\x00" * (HASH_LEN - 1))
+    with pytest.raises(ValidationError):
+        ta.validate_python(b"\x00" * (HASH_LEN + 1))
+
+
+def test_algorand_hash_length_in_bounds():
+    """Test that `AlgorandHash` does not raise an error if the value is in bounds."""
+    ta = TypeAdapter(AlgorandHash)
+    assert ta.validate_python(b"\x00" * HASH_LEN) == b"\x00" * HASH_LEN
+
+
+def test_algorand_address_invalid():
+    """Test that `AlgorandAddress` raises an error if the value is invalid."""
+    ta = TypeAdapter(AlgorandAddress)
+    with pytest.raises(ValidationError):
+        ta.validate_python("")
+    with pytest.raises(ValidationError):
+        ta.validate_python(
+            "1234567890123456789012345678901234567890123456789012345678901234"
+        )
+
+
+def test_algorand_address_valid():
+    """Test that `AlgorandAddress` does not raise an error if the value is valid."""
+    ta = TypeAdapter(AlgorandAddress)
+    assert (
+        ta.validate_python("VCMJKWOY5P5P7SKMZFFOCEROPJCZOTIJMNIYNUCKH7LRO45JMJP6UYBIJA")
+        == "VCMJKWOY5P5P7SKMZFFOCEROPJCZOTIJMNIYNUCKH7LRO45JMJP6UYBIJA"
+    )
+
+
+def test_asa_decimals_out_of_bounds():
+    """Test that `AsaDecimals` raises an error if the value is out of bounds."""
+    ta = TypeAdapter(AsaDecimals)
+    with pytest.raises(ValidationError):
+        ta.validate_python(-1)
+    with pytest.raises(ValidationError):
+        ta.validate_python(20)
+
+
+def test_asa_decimals_in_bounds():
+    """Test that `AsaDecimals` does not raise an error if the value is in bounds."""
+    ta = TypeAdapter(AsaDecimals)
+    assert ta.validate_python(0) == 0
+    assert ta.validate_python(1) == 1
+    assert ta.validate_python(MAX_ASSET_DECIMALS) == MAX_ASSET_DECIMALS
+
+
+def test_asa_url_encoded_length_out_of_bounds():
+    """Test that `AsaUrl` raises an error if the encoded length of the value is out of bounds."""
+    ta = TypeAdapter(AsaUrl)
+    with pytest.raises(ValidationError):
+        ta.validate_python(
+            "https://www.example.com/1234567890123456789012345678901234567890123456789012345678901234567890123"
+        )
+
+
+def test_asa_url_invalid():
+    """Test that `AsaUrl` raises an error if the value is invalid."""
+    ta = TypeAdapter(AsaUrl)
+    with pytest.raises(ValidationError):
+        ta.validate_python("example.com")
+
+
+def test_asa_url_valid():
+    """Test that `AsaUrl` does not raise an error if the the value is a valid URL and its encoded length is in bounds."""
+    ta = TypeAdapter(AsaUrl)
+    assert (
+        ta.validate_python("https://www.example.com/").unicode_string()
+        == "https://www.example.com/"
+    )
+
+
+def test_asa_unit_name_encoded_length_out_of_bounds():
+    """Test that `AsaUnitName` raises an error if the encoded length of the value is out of bounds."""
+    ta = TypeAdapter(AsaUnitName)
+    with pytest.raises(ValidationError):
+        ta.validate_python("A" * 9)
+
+
+def test_asa_unit_name_valid():
+    """Test that `AsaUnitName` does not raise an error if the encoded length of the value is in bounds."""
+    ta = TypeAdapter(AsaUnitName)
+    assert ta.validate_python("USDC") == "USDC"
+
+
+def test_asa_asset_name_encoded_length_out_of_bounds():
+    """Test that `AsaAssetName` raises an error if the encoded length of the value is out of bounds."""
+    ta = TypeAdapter(AsaAssetName)
+    with pytest.raises(ValidationError):
+        ta.validate_python("A" * 33)
+
+
+def test_asa_asset_name_valid():
+    """Test that `AsaAssetName` does not raise an error if the encoded length of the value is in bounds."""
+    ta = TypeAdapter(AsaAssetName)
+    assert ta.validate_python("USD Coin") == "USD Coin"

--- a/tests/test_utils/test_read.py
+++ b/tests/test_utils/test_read.py
@@ -1,6 +1,5 @@
 """Unit tests for the humblepy.utils.read functions."""
 
-
 from humblepy.utils.read import read_ipfs_gateways
 
 


### PR DESCRIPTION
## Description

Adding annotated types and a Pydantic model for Algorand Standard Assets (ASAs).

## Related Issue

## Type of Change

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/code-alexander/humblepy/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/code-alexander/humblepy/blob/main/CONTRIBUTING.md) guide.
- [x] I've updated the code style using `make codestyle`.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in Google format for all the methods and classes that I used.
