### PR TITLE
fix: nft.storage fetch pin status method

### DIFF
--- a/algobase/ipfs/client_base.py
+++ b/algobase/ipfs/client_base.py
@@ -2,6 +2,7 @@
 
 from abc import ABC, abstractmethod
 
+import httpx
 from decouple import UndefinedValueError, config
 
 from algobase.choices import IpfsPinStatusChoice, IpfsProviderChoice
@@ -30,7 +31,7 @@ class IpfsClient(ABC):
 
     @property
     @abstractmethod
-    def base_url(self) -> str:
+    def base_url(self) -> httpx.URL:
         """The base URL of the IPFS provider's API."""
         ...  # pragma: no cover
 
@@ -58,25 +59,25 @@ class IpfsClient(ABC):
             )
 
     @abstractmethod
-    def store_json(self, json: str) -> str | None:
+    def store_json(self, json: str) -> str:
         """Stores JSON data in IPFS.
 
         Args:
             json (str): The JSON to store.
 
         Returns:
-            str | None: The IPFS CID of the stored data, or None if the data could not be stored.
+            str: The IPFS CID of the stored data.
         """
         ...  # pragma: no cover
 
     @abstractmethod
-    def fetch_pin_status(self, cid: str) -> IpfsPinStatusChoice | None:
+    def fetch_pin_status(self, cid: str) -> IpfsPinStatusChoice:
         """Returns the pinning status of a file, by CID.
 
         Args:
             cid (str): The CID of the file to check.
 
         Returns:
-            IpfsPinStatusChoice | None: The pin status of the CID, or None if the status could not be retrieved.
+            IpfsPinStatusChoice: The pin status of the CID.
         """
         ...  # pragma: no cover

--- a/algobase/ipfs/nft_storage.py
+++ b/algobase/ipfs/nft_storage.py
@@ -1,7 +1,6 @@
 """IPFS client for nft.storage."""
 
 from dataclasses import dataclass
-from urllib.parse import urljoin
 
 import httpx
 
@@ -32,9 +31,9 @@ class NftStorage(IpfsClient):
         return "1.0"
 
     @property
-    def base_url(self) -> str:
+    def base_url(self) -> httpx.URL:
         """The base URL of the IPFS provider's API."""
-        return "https://api.nft.storage"
+        return httpx.URL("https://api.nft.storage")
 
     @property
     def is_api_key_required(self) -> bool:
@@ -46,18 +45,18 @@ class NftStorage(IpfsClient):
         """The headers to use for the HTTP requests."""
         return {"Authorization": f"Bearer {self.api_key}"}
 
-    def store_json(self, json: str) -> str | None:
+    def store_json(self, json: str) -> str:
         """Stores JSON data in IPFS.
 
         Args:
             json (str): The JSON to store.
 
         Returns:
-            str | None: The IPFS CID of the stored data, or None if the data could not be stored.
+            str: The IPFS CID of the stored data.
         """
         with httpx.Client() as client:
             response = client.post(
-                url=urljoin(self.base_url, "upload"),
+                url=self.base_url.join("upload"),
                 json=json,
                 headers=self.headers,
                 timeout=10.0,
@@ -78,19 +77,18 @@ class NftStorage(IpfsClient):
                     f"HTTP Exception for {response.request.url}: {response.status_code} {data.get('error').get('message')}"
                 )
 
-    def fetch_pin_status(self, cid: str) -> IpfsPinStatusChoice | None:
+    def fetch_pin_status(self, cid: str) -> IpfsPinStatusChoice:
         """Returns the pinning status of a file, by CID.
 
         Args:
             cid (str): The CID of the file to check.
 
         Returns:
-            IpfsPinStatusChoice | None: The pin status of the CID, or None if the status could not be retrieved.
+            IpfsPinStatusChoice: The pin status of the CID.
         """
         with httpx.Client() as client:
             response = client.get(
-                url=urljoin(self.base_url, "check"),
-                params={"cid": cid},
+                url=self.base_url.join(f"check/{cid}"),
                 headers=self.headers,
                 timeout=10.0,
             )

--- a/docs/how_to/how_to_store_json_ipfs.md
+++ b/docs/how_to/how_to_store_json_ipfs.md
@@ -1,4 +1,4 @@
-# How to Store JSON in IPFS
+# How to Store and Pin JSON in IPFS
 
 ## ⚠️ Warning
 
@@ -20,7 +20,13 @@ Sign up for an [nft.storage account](https://nft.storage/docs/#create-an-account
 
 You will need to set the API key as an environment variable called `NFT_STORAGE_API_KEY`, or add it to your .env file.
 
-To set the environment variable in Python:
+`algobase` uses the [dotenv](https://github.com/theskumar/python-dotenv/tree/main?tab=readme-ov-file#command-line-interface) library. You can use its CLI to set the variable:
+
+```
+dotenv set NFT_STORAGE_API_KEY <your-api-key>
+```
+
+Otherwise, to set the environment variable in Python:
 
 ```python
 import os
@@ -28,13 +34,7 @@ import os
 os.environ["NFT_STORAGE_API_KEY"] = "<your-api-key>"
 ```
 
-`algobase` uses the [dotenv](https://github.com/theskumar/python-dotenv/tree/main?tab=readme-ov-file#command-line-interface) library. You can use its CLI to set the variable:
-
-```
-dotenv set NFT_STORAGE_API_KEY <your-api-key>
-```
-
-## How to Store JSON in IPFS
+## How to Store JSON in IPFS and Check it's Pinned
 
 ```python
 from algobase.ipfs.nft_storage import NftStorage
@@ -50,5 +50,13 @@ cid = client.store_json(
 print(f"Stored JSON on IPFS with CID {cid}")
 """
 Stored JSON on IPFS with CID bafkreiaci6q6dolsy32cnqhtmgvf23gzphzzc7urfnka2omgzn7behvbx4
+"""
+
+# Check IPFS pin status ('queued', 'pinning', 'pinned', or 'failed')
+pin_status = client.fetch_pin_status(cid)
+
+print(f"IPFS pin status for CID {cid} is '{pin_status}'")
+"""
+IPFS pin status for CID bafkreiaci6q6dolsy32cnqhtmgvf23gzphzzc7urfnka2omgzn7behvbx4 is 'pinned'
 """
 ```

--- a/examples/store_json_ipfs.py
+++ b/examples/store_json_ipfs.py
@@ -17,3 +17,11 @@ print(f"Stored JSON on IPFS with CID {cid}")
 """
 Stored JSON on IPFS with CID bafkreiaci6q6dolsy32cnqhtmgvf23gzphzzc7urfnka2omgzn7behvbx4
 """
+
+# Check IPFS pin status ('queued', 'pinning', 'pinned', or 'failed')
+pin_status = client.fetch_pin_status(cid)
+
+print(f"IPFS pin status for CID {cid} is '{pin_status}'")
+"""
+IPFS pin status for CID bafkreiaci6q6dolsy32cnqhtmgvf23gzphzzc7urfnka2omgzn7behvbx4 is 'pinned'
+"""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "algobase"
-version = "0.9.2"
+version = "0.9.3"
 description = "A type-safe Python library for interacting with assets on Algorand."
 readme = "README.md"
 authors = ["algobase <alexandercodes@proton.me>"]

--- a/tests/test_ipfs/test_client_base.py
+++ b/tests/test_ipfs/test_client_base.py
@@ -2,6 +2,7 @@
 
 from dataclasses import dataclass
 
+import httpx
 import pytest
 from _pytest.monkeypatch import MonkeyPatch
 from decouple import UndefinedValueError
@@ -33,34 +34,34 @@ class TestIpfsClient:
             return "1.0"
 
         @property
-        def base_url(self) -> str:
+        def base_url(self) -> httpx.URL:
             """The base URL of the IPFS provider's API."""
-            return "https://api.nft.storage"
+            return httpx.URL("https://api.nft.storage")
 
         @property
         def is_api_key_required(self) -> bool:
             """Whether the IPFS provider requires an API key."""
             return True
 
-        def store_json(self, json: str) -> str | None:
+        def store_json(self, json: str) -> str:
             """Stores JSON data in IPFS.
 
             Args:
                 json (str): The JSON to store.
 
             Returns:
-                str | None: The IPFS CID of the stored data, or None if the data could not be stored.
+                str: The IPFS CID of the stored data.
             """
             return "some_cid"
 
-        def fetch_pin_status(self, cid: str) -> IpfsPinStatusChoice | None:
+        def fetch_pin_status(self, cid: str) -> IpfsPinStatusChoice:
             """Returns the pinning status of a file, by CID.
 
             Args:
                 cid (str): The CID of the file to check.
 
             Returns:
-                IpfsPinStatusChoice | None: The status of the CID, or None if the status could not be retrieved.
+                IpfsPinStatusChoice: The status of the CID.
             """
             return IpfsPinStatus.PINNED
 


### PR DESCRIPTION
## Description

Fixing the fetch_pin_status() method for the nft.storage client.
Adding example code and updating docs for the IPFS JSON guide.
Switching `base_url` in the IPFS client ABC and nft.storage client to be type httpx.URL.
Replacing urllib.parse.urljoin with the join() method of httpx.URL.

## Related Issue

## Type of Change

- [x] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/code-alexander/algobase/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/code-alexander/algobase/blob/main/CONTRIBUTING.md) guide.
- [x] I've updated the code style using `make codestyle`.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in Google format for all the methods and classes that I used.
