### PR TITLE
chore: updating release workflow trigger conditions

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -2,13 +2,36 @@ name: Publish Python 🐍 distribution 📦 to PyPI
 
 on:
   push:
-    # branches to consider in the event; optional, defaults to all
-    branches:
-      - main
+    tags:
+      - "v*.*.*"
 
 jobs:
+  on-main-branch-check:
+    runs-on: ubuntu-latest
+    outputs:
+      on_main: ${{ steps.contains_tag.outputs.retval }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: rickstaa/action-contains-tag@v1
+        id: contains_tag
+        with:
+          reference: "main"
+          tag: "${{ github.ref }}"
+
+  tag-not-on-main-job:
+    runs-on: ubuntu-latest
+    needs: on-main-branch-check
+    if: ${{ needs.on-main-branch-check.outputs.on_main != 'true' }}
+    steps:
+      - run: echo "Tag was not pushed to main."
+      - run: echo ${{needs.on-main-branch-check.outputs.on_main}}
+
   build:
     runs-on: ubuntu-latest
+    needs: on-main-branch-check
+    if: ${{ needs.on-main-branch-check.outputs.on_main == 'true' }}
     outputs:
       release_tag: ${{ steps.set_release_tag.outputs.release_tag }}
     strategy:


### PR DESCRIPTION
## Description

Changing the publish-to-pypi.yml workflow so that it only publishes a new release when a tag is pushed to the main branch.

## Related Issue

## Type of Change

- [x] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/code-alexander/algobase/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/code-alexander/algobase/blob/main/CONTRIBUTING.md) guide.
- [x] I've updated the code style using `make codestyle`.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in Google format for all the methods and classes that I used.
