### PR TITLE
Feature/algo/client

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -546,13 +546,13 @@ cython = ["cython"]
 
 [[package]]
 name = "datamodel-code-generator"
-version = "0.25.3"
+version = "0.25.4"
 description = "Datamodel Code Generator"
 optional = false
 python-versions = ">=3.7,<4.0"
 files = [
-    {file = "datamodel_code_generator-0.25.3-py3-none-any.whl", hash = "sha256:3d5c65194690c07f5fcd4aff6fc2e4ad135e5deab63cc885f62dfcfaf17e4b9c"},
-    {file = "datamodel_code_generator-0.25.3.tar.gz", hash = "sha256:523da03ad2abae73ec1d68124563cd221a5f7e93b0d403204a8acd4d67df69ae"},
+    {file = "datamodel_code_generator-0.25.4-py3-none-any.whl", hash = "sha256:cbf179517c610dce81589203d72b52e6ab848d78cb57264c1e5d929a9cc9d9a4"},
+    {file = "datamodel_code_generator-0.25.4.tar.gz", hash = "sha256:8e64c94a3bc92c69a6f56de84f0d61f70fd65c2e0ac95a27ce66837bd04c5492"},
 ]
 
 [package.dependencies]
@@ -1840,7 +1840,6 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
-    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
     {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
     {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
     {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "algobase"
-version = "0.12.0"
+version = "0.12.1"
 description = "A type-safe Python library for interacting with assets on Algorand."
 readme = "README.md"
 authors = ["algobase <alexandercodes@proton.me>"]

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -31,13 +31,13 @@ def test_maybe_apply_cast_none(x: None, f: type[T]) -> None:
 
 def test_provide_context() -> None:
     """Tests the provide_context() function."""
-    context = provide_context(1, 2, 3, a=4, b=5, c=6)
+    context = provide_context(a=4, b=5, c=6)
 
     def f(x, y, z, a, b, c):
         """Function that accepts context arguments."""
         return x + y + z + a + b + c
 
-    assert context(f) == 21
+    assert context(f, 1, 2, z=3) == 21
 
 
 def test_first_true() -> None:


### PR DESCRIPTION
## Description

Changing the provide_context() function so that it only accepts key word arguments.
The inner function can then take arbitrary args and kwargs.

This makes it easier to understand the results.

It also now prioritises kwargs passed to the inner function, and will not apply any kwargs passed as initial context that can't be passed to the inner function.

## Related Issue

## Type of Change

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/code-alexander/algobase/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/code-alexander/algobase/blob/main/CONTRIBUTING.md) guide.
- [x] I've updated the code style using `make codestyle`.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in Google format for all the methods and classes that I used.
