### PR TITLE
feat: construct dispenser API client from settings

### DIFF
--- a/algobase/settings.py
+++ b/algobase/settings.py
@@ -32,9 +32,11 @@ class Settings(BaseSettings):
         description="The Algorand API provider.", default=AlgorandApiProvider.LOCALHOST
     )
     algod_token: str = Field(description="The Algod API token.", default="a" * 64)
-
     nft_storage_api_key: str | None = Field(
         description="API key for nft.storage.", default=None
+    )
+    testnet_dispenser_access_token: str | None = Field(
+        description="Access token for the Algorand TestNet dispenser.", default=None
     )
 
     def __or__(self, f: Callable[[Self], T]) -> T:


### PR DESCRIPTION
## Description

Adding ability to construct dispenser API client from settings object.

## Related Issue

## Type of Change

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/code-alexander/algobase/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/code-alexander/algobase/blob/main/CONTRIBUTING.md) guide.
- [x] I've updated the code style using `make codestyle`.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in Google format for all the methods and classes that I used.
