### PR TITLE
fix: decode metadata-hash

### DIFF
--- a/algobase/models/asset_params.py
+++ b/algobase/models/asset_params.py
@@ -1,5 +1,6 @@
 """A Pydantic model for Algorand Standard Asset parameters."""
 
+from base64 import b64decode
 from typing import Self
 
 from algosdk.v2client.algod import AlgodClient
@@ -81,8 +82,14 @@ class AssetParams(BaseModel):
         Returns:
             Self: The `AssetParams` instance.
         """
+        response = algod_client.asset_info(asset_id)["asset"]  # type: ignore[call-overload]
+        response["params"]["metadata-hash"] = (
+            b64decode(response["params"]["metadata-hash"])
+            if "metadata-hash" in response["params"]
+            else None
+        )
         if asset_id:
-            asset = Asset.model_validate(algod_client.asset_info(asset_id)["asset"])  # type: ignore[call-overload]
+            asset = Asset.model_validate(response)
             return cls.model_validate(asset.params.model_dump())
         return cls(
             total=10_000_000_000,

--- a/tests/test_models/test_asset_params.py
+++ b/tests/test_models/test_asset_params.py
@@ -151,6 +151,7 @@ class TestAssetParams:
                     "default-frozen": False,
                     "freeze": "3ERES6JFBIJ7ZPNVQJNH2LETCBQWUPGTO4ROA6VFUR25WFSYKGX3WBO5GE",
                     "manager": "37XL3M57AXBUJARWMT5R7M35OERXMH3Q22JMMEFLBYNDXXADGFN625HAL4",
+                    "metadata-hash": "MWQ3NWYwNGYwZmE5NDA3MDkxOWZkZDNlY2FhMmM1ZmQ=",
                     "name": "USDC",
                     "name-b64": "VVNEQw==",
                     "reserve": "2UEQTE5QDNXPI7M3TU44G6SYKLFWLPQO7EBZM7K7MHMQQMFI4QJPLHQFHM",


### PR DESCRIPTION
## Description

The optional metadata-hash in Algod `asset_info` response was causing a Pydantic validation error.
Fixed by decoding.

## Related Issue

## Type of Change

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/code-alexander/algobase/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/code-alexander/algobase/blob/main/CONTRIBUTING.md) guide.
- [x] I've updated the code style using `make codestyle`.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in Google format for all the methods and classes that I used.
