### PR TITLE
fix: prevent Algod error when fetching asset ID 0

### DIFF
--- a/algobase/models/asset_params.py
+++ b/algobase/models/asset_params.py
@@ -82,13 +82,13 @@ class AssetParams(BaseModel):
         Returns:
             Self: The `AssetParams` instance.
         """
-        response = algod_client.asset_info(asset_id)["asset"]  # type: ignore[call-overload]
-        response["params"]["metadata-hash"] = (
-            b64decode(response["params"]["metadata-hash"])
-            if "metadata-hash" in response["params"]
-            else None
-        )
         if asset_id:
+            response = algod_client.asset_info(asset_id)["asset"]  # type: ignore[call-overload]
+            response["params"]["metadata-hash"] = (
+                b64decode(response["params"]["metadata-hash"])
+                if "metadata-hash" in response["params"]
+                else None
+            )
             asset = Asset.model_validate(response)
             return cls.model_validate(asset.params.model_dump())
         return cls(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "algobase"
-version = "0.12.6"
+version = "0.12.7"
 description = "A type-safe Python library for interacting with assets on Algorand."
 readme = "README.md"
 authors = ["algobase <alexandercodes@proton.me>"]


### PR DESCRIPTION
## Description

Avoid calling `asset_info` Algod method for asset ID 0 (ALGO).

## Related Issue

## Type of Change

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/code-alexander/algobase/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/code-alexander/algobase/blob/main/CONTRIBUTING.md) guide.
- [x] I've updated the code style using `make codestyle`.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in Google format for all the methods and classes that I used.
