### PR TITLE
fix: handle different algod asset_info response schema

### DIFF
--- a/algobase/models/asset_params.py
+++ b/algobase/models/asset_params.py
@@ -83,13 +83,14 @@ class AssetParams(BaseModel):
             Self: The `AssetParams` instance.
         """
         if asset_id:
-            response = algod_client.asset_info(asset_id)["asset"]  # type: ignore[call-overload]
-            response["params"]["metadata-hash"] = (
-                b64decode(response["params"]["metadata-hash"])
-                if "metadata-hash" in response["params"]
+            response = algod_client.asset_info(asset_id)
+            data = response.get("asset", response)  # type: ignore[union-attr]
+            data["params"]["metadata-hash"] = (
+                b64decode(data["params"]["metadata-hash"])
+                if "metadata-hash" in data["params"]
                 else None
             )
-            asset = Asset.model_validate(response)
+            asset = Asset.model_validate(data)
             return cls.model_validate(asset.params.model_dump())
         return cls(
             total=10_000_000_000,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "algobase"
-version = "0.12.7"
+version = "0.12.8"
 description = "A type-safe Python library for interacting with assets on Algorand."
 readme = "README.md"
 authors = ["algobase <alexandercodes@proton.me>"]

--- a/tests/test_models/test_asset_params.py
+++ b/tests/test_models/test_asset_params.py
@@ -170,6 +170,30 @@ class TestAssetParams:
         assert asset_params.asset_name == "USDC"
         assert asset_params.decimals == 6
 
+        algod_client.asset_info = lambda _: {
+            "index": 31566704,
+            "params": {
+                "creator": "2UEQTE5QDNXPI7M3TU44G6SYKLFWLPQO7EBZM7K7MHMQQMFI4QJPLHQFHM",
+                "decimals": 6,
+                "default-frozen": False,
+                "freeze": "3ERES6JFBIJ7ZPNVQJNH2LETCBQWUPGTO4ROA6VFUR25WFSYKGX3WBO5GE",
+                "manager": "37XL3M57AXBUJARWMT5R7M35OERXMH3Q22JMMEFLBYNDXXADGFN625HAL4",
+                "name": "USDC",
+                "name-b64": "VVNEQw==",
+                "reserve": "2UEQTE5QDNXPI7M3TU44G6SYKLFWLPQO7EBZM7K7MHMQQMFI4QJPLHQFHM",
+                "total": 18446744073709551615,
+                "unit-name": "USDC",
+                "unit-name-b64": "VVNEQw==",
+                "url": "https://www.centre.io/usdc",
+                "url-b64": "aHR0cHM6Ly93d3cuY2VudHJlLmlvL3VzZGM=",
+            },
+        }
+        asset_params = AssetParams.from_algod(algod_client, 31566704)  # type: ignore[arg-type]
+
+        assert asset_params.unit_name == "USDC"
+        assert asset_params.asset_name == "USDC"
+        assert asset_params.decimals == 6
+
         asset_params = AssetParams.from_algod(algod_client, 0)  # type: ignore[arg-type]
 
         assert asset_params.unit_name == "ALGO"


### PR DESCRIPTION
## Description

Adding step to handle case where Algod `asset_info` response has or doesn't have an "asset" key (both seem to occur for different asset IDs).

## Related Issue

## Type of Change

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/code-alexander/algobase/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/code-alexander/algobase/blob/main/CONTRIBUTING.md) guide.
- [x] I've updated the code style using `make codestyle`.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in Google format for all the methods and classes that I used.
